### PR TITLE
Fix for Pi not completing its daily shutdown

### DIFF
--- a/cron/reboot.py
+++ b/cron/reboot.py
@@ -6,6 +6,7 @@
 
 import os
 import sys
+sys.path.append('..')
 
 from main import Main
 

--- a/main.py
+++ b/main.py
@@ -126,7 +126,12 @@ class Main:
         MinePi
         
         '''
-        self.mailer.sendMail('michael.craun@gmail.com', subject, body, [self.bootlog, self.logfile])
+
+        # Files sent to the sendMail method cannot be string references, so we will create os path references
+        # for these files before sending them
+        bootlog = os.path.join(self.rootDir, self.bootlog)
+        logfile = os.path.join(self.rootDir, self.logfile)
+        self.mailer.sendMail('michael.craun@gmail.com', subject, body, [bootlog, logfile])
         
     # WARN: Should only be called when first creating the MinePi server and/or when transferring the server to 
     # another RasPi!

--- a/test.py
+++ b/test.py
@@ -1,4 +1,0 @@
-from main import Main
-
-main = Main()
-main.commands()


### PR DESCRIPTION
Main.sendLogs() was not properly passing file references to the Mailer, thus causing an exception and never getting to the reboot command. 