### PR TITLE
Installer fixes and beefier logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,16 @@ Directories: below is a list of important directories and their purpose:
 
 ## Cost
 For convenience, the total cost of the MinePi project is broken down in the table below. The costs listed are in USD and are current as of 11/19/2021. 
-<!-- TODO: Add cost table -->
+
+| Part | Cost | Link |
+|:---|:---:|:---|
+| Raspberry Pi 4B (4GB RAM minimum) | $55 | [Adafruit](https://www.adafruit.com/product/4296) |
+| Raspberry Pi 4B Heatsinks | $6.99 | [Amazon](https://www.amazon.com/dp/B07W664LNN?psc=1&ref=ppx_yo2_dt_b_product_details) |
+| 30mm 3.3V 5V Cooling Fan | $9.99 | [Amazon](https://www.amazon.com/dp/B0792BW2VH?psc=1&ref=ppx_yo2_dt_b_product_details) |
+| Custom 3D Printed Case | $0.25 | [Thangs]() |
+| USB-A to USB-C Cable | $9.74 | [Amazon](https://www.amazon.com/AmazonBasics-Type-C-USB-Male-Cable/dp/B01GGKYQ02/ref=sr_1_1_sspa?crid=1SIMJT6A8MI11&keywords=usb+to+usb+c+cable&qid=1637385396&s=electronics&sprefix=usba+to+us%2Celectronics%2C190&sr=1-1-spons&psc=1&spLa=ZW5jcnlwdGVkUXVhbGlmaWVyPUFUMTY2UEJHSFQyWFMmZW5jcnlwdGVkSWQ9QTA1NTIyMjI3WEFQWlBBNk80WkgmZW5jcnlwdGVkQWRJZD1BMDE0NDE4NDNHSlhPWTk1UEY2SFkmd2lkZ2V0TmFtZT1zcF9hdGYmYWN0aW9uPWNsaWNrUmVkaXJlY3QmZG9Ob3RMb2dDbGljaz10cnVl) |
+| USB-A 5V Power Supply | $10.99 | [Amazon](https://www.amazon.com/dp/B06XG1CQN2?psc=1&ref=ppx_yo2_dt_b_product_details) |
+| | | |
 
 ## Installation
 

--- a/minecraft/install.py
+++ b/minecraft/install.py
@@ -37,20 +37,22 @@ class Installer:
         # Otherwise, if latest does not match current, user should be alerted
         if shouldInstallLatest: 
             self.installLatest(latest)
-        elif current != latest:
-            build = latest['build']
-            version = latest['version']
-            message = 'Version {}:{} has been released! Please consider updating!'.format(version, build)
-            log(message)
+        else:
+            currentVersion = current['version']
+            latestVersion = latest['version']
+            if currentVersion != latestVersion:
+                build = latest['build']
+                message = 'Version {}:{} has been released! Please consider updating!'.format(latestVersion, build)
+                log(message)
 
-        log('Version {}:{} has been installed...'.format(latest['version'], latest['build']))
+        log('Latest version [{}:{}] has been installed...'.format(latest['version'], latest['build']))
 
-    def installLatest(self, version):
+    def installLatest(self, latest):
         # Construct download url and download
         log('Downloading latest build of server jar...')
-        build = version['build']
-        file = version['filename']
-        version = version['version']
+        build = latest['build']
+        file = latest['filename']
+        version = latest['version']
         url = self.downloadUrlTemplate.format(version, build, file)
         source = self.downloadFrom(url)
         
@@ -59,6 +61,10 @@ class Installer:
         if os.path.isdir(self.serverDir) == False:
             os.mkdir(self.serverDir)
         os.replace(source, self.serverJar)
+
+        # Update the version log with the new server jar info
+        print(latest)
+        self.versioner.updateInstalledVersion(latest)
 
     def downloadFrom(self, url):
         with requests.get(url, stream=True) as request:

--- a/minecraft/install.py
+++ b/minecraft/install.py
@@ -12,6 +12,7 @@ import sys
 sys.path.append('..')
 
 from minecraft.version import Versioner
+from util.emailer import PiMailer
 from util.logger import log
 
 class Installer:
@@ -38,12 +39,29 @@ class Installer:
         if shouldInstallLatest: 
             self.installLatest(latest)
         else:
+            # Has a new version of the Paper Minecraft server been released?
             currentVersion = current['version']
             latestVersion = latest['version']
+
+            # If so, log it and send an email to the user
             if currentVersion != latestVersion:
                 build = latest['build']
                 message = 'Version {}:{} has been released! Please consider updating!'.format(latestVersion, build)
                 log(message)
+
+                mailer = PiMailer('smtp.gmail.com', 587, 'ras.pi.craun@gmail.com', 'dymdu9-vowjIt-kejvah')
+                subject = 'Version {}:{} has been released!'.format(latestVersion, build)
+                body = '''
+                Hey there! 
+
+                Great news! Version {}:{} has been released! I won't install major or minor updates for you so you don't lose any data, but you should consider updating when you get a chance.
+
+                Don't worry about remembering, though; I'll send you an email every time I reboot. :)
+
+                Thanks a bunch,
+                MinePi
+                '''.format(latestVersion, build)
+                mailer.sendMail('michael.craun@gmail.com', subject, body)
 
         log('Latest version [{}:{}] has been installed...'.format(latest['version'], latest['build']))
 

--- a/minecraft/version.py
+++ b/minecraft/version.py
@@ -9,6 +9,7 @@ import re
 import requests
 
 from util import logger
+from util.date import Date
 
 class Versioner:
     dir = os.path.dirname(__file__)
@@ -141,6 +142,26 @@ class Versioner:
             changelog = open(self.changelog, 'r').read()
             if '[INSTALL]' in changelog: return True
             else: return False
+
+    # Simply updates the version log with a new version. 
+    # WARN: Should only be called from the installer when a new version is installed!
+    def updateInstalledVersion(self, version):
+        # Update current version properties with new version properties
+        # This doesn't currently have any effect, but could in the future, so I'm doing it now
+        newBuild = version['build']
+        newGroup = version['versionGroup']
+        newVersion = version['version']
+        self.currentBuild = newBuild
+        self.currentVersion = newVersion
+        self.currentVersionGroup = newVersion
+
+        # Register the install in the versionlog file
+        # Like: [INSTALL - 11/17/2021 06:54:37] 1.17:1.17.1:383
+        timestamp = Date().timestamp()
+        message = '[INSTALL - {}] {}:{}:{}\n'.format(timestamp, newGroup, newVersion, newBuild)
+        versionlog = open(self.versionlog, 'a')
+        versionlog.write(message)
+        versionlog.close()
 
 
 

--- a/test.py
+++ b/test.py
@@ -1,5 +1,5 @@
-from util import logger
+from minecraft.install import Installer
 
-if __name__ == "__main__":
-	# logger.handleUncaughtException(RuntimeError("Test"))
-    raise RuntimeError("Test unhandled")
+installer = Installer()
+installer.install()
+

--- a/util/logger.py
+++ b/util/logger.py
@@ -1,31 +1,37 @@
 import os
 import sys
+import traceback
 
 from .date import Date
 from .emailer import PiMailer
 
 # set the excepthook to route through the MinePi logger
-sys.excepthook = lambda type, value, tb: handleUncaughtException(value)
+sys.excepthook = lambda type, value, tb: handleUncaughtException(type, value, tb)
 
 utilDir = os.path.dirname(__file__)
 rootDir = os.path.join(utilDir, '..')
 logfile = os.path.join(rootDir, 'logs.txt')
 logs = None
 
-def handleUncaughtException(exception):
+def handleUncaughtException(type, exception, tb):
+	error = repr(exception)
+	trace = ''.join(traceback.format_tb(tb))
+	print('{}\nTraceback (most recent call last):\n{}'.format(error, trace))
+
 	subject = 'Uncaught Exception Encountered!'
 	body = '''
 	Hey there! 
-	Wish I was bringing you better news, but it looks like your MinePi has encountered an uncaught exception:
+	Wish I was bringing you better news, but it looks like I've encountered an unhandled exception:
 	
 	{}
-
+	Traceback (most recent call last):
+	{}
 	Unfotunately, this means that the server has failed to start...
-	Either resolve the issue yourself or contact support with a copy of your log files.
+	Either resolve the issue yourself or forward this email to support with a copy of your logs.
 
 	Thanks,
 	MinePi
-	'''.format(exception)
+	'''.format(error, trace)
 	mailer = PiMailer('smtp.gmail.com', 587, 'ras.pi.craun@gmail.com', 'dymdu9-vowjIt-kejvah')
 	mailer.sendMail('michael.craun@gmail.com', subject, body)
 


### PR DESCRIPTION
- Fixed a bug where the Installer was downloading and installing the latest build of the Paper Minecraft server regardless of what build was last installed. The latest installed version was not being logged as having been installed after updating.
- Fixed a bug where the "[version] has been released! Please consider upgrading!" message was being logged when there had been no new version released.
- Installer now sends the owner an email when a new minor or major release is detected.
- handleUncaughtException now includes the exception's traceback in the email sent to the owner.